### PR TITLE
fix import error version.py for fedora 39 [SRE-7997]

### DIFF
--- a/version.py
+++ b/version.py
@@ -6,7 +6,7 @@ Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
 
-import imp
+import importlib.util
 import os
 import subprocess
 
@@ -24,7 +24,15 @@ def save_version(new_ver, old_ver, version_file):
 def get_project_version(version_file):
     version_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), version_file)
     try:
-        module = imp.load_source("verfile", version_file)
+        # Load the source file using SourceFileLoader
+        loader = importlib.machinery.SourceFileLoader("verfile", version_file)
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        module = importlib.util.module_from_spec(spec)
+
+        # Execute the module code
+        loader.exec_module(module)
+
+        # Access the version attribute from the module
         file_ver = module.__version__
     except IOError:
         file_ver = None


### PR DESCRIPTION
Package build failure on fedora 39, seen below:
```
[2024-01-21T10:54:07.962Z] + python3 setup.py install --root=/srv/jenkins/workspace/aiven-deps-mb-f38-x86_64_main/rpmbuild/BUILDROOT/pglookout-2.0.2-11.fc39.x86_64
[2024-01-21T10:54:07.962Z] Traceback (most recent call last):
[2024-01-21T10:54:07.962Z]   File "/srv/jenkins/workspace/aiven-deps-mb-f38-x86_64_main/rpmbuild/BUILD/pglookout-028ba9e6002c8a50c6c7f8147ab02620e12f12f7/setup.py", line 4, in <module>
[2024-01-21T10:54:07.962Z]     import version
[2024-01-21T10:54:07.962Z]   File "/srv/jenkins/workspace/aiven-deps-mb-f38-x86_64_main/rpmbuild/BUILD/pglookout-028ba9e6002c8a50c6c7f8147ab02620e12f12f7/version.py", line 9, in <module>
[2024-01-21T10:54:07.962Z]     import imp
[2024-01-21T10:54:07.962Z] ModuleNotFoundError: No module named 'imp'
```