### PR TITLE
Decide to failover based on uptodate info

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -30,6 +30,7 @@ def pgl():
     pgl_.cluster_monitor._connect_to_db = Mock()  # pylint: disable=protected-access
     pgl_.create_alert_file = Mock()
     pgl_.execute_external_command = Mock()
+    pgl_.failover_decision_queue = Mock()
     try:
         yield pgl_
     finally:


### PR DESCRIPTION
When we notice the primary node has gone, we need to get up to date information from the other standby nodes if needed.