### PR TITLE
Fix a potential issue with race condition when reloading a config

### DIFF
--- a/pglookout/pglookout.py
+++ b/pglookout/pglookout.py
@@ -859,8 +859,12 @@ class PgLookout:
     def main_loop(self):
         while self.running:
             if self.config_reload_pending:
-                self.load_config()
                 self.config_reload_pending = False
+                try:
+                    self.load_config()
+                except:
+                    self.config_reload_pending = True
+                    raise
             try:
                 self._apply_latest_config_version()
             except Exception as ex:  # pylint: disable=broad-except


### PR DESCRIPTION
When SIGHUP is sent during `load_config` it's possible that `config_reload_pending` will be set to `False` (thus overwriting the `True` value, which was set in signal handler) and new reload won't happen.