### PR TITLE
pglookout: support explicit failover priorities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -295,6 +295,14 @@ over_warning_limit_command and to create a warning file.
 
 Shell command to execute in case the node has deemed itself in need of promotion
 
+``failover_priorities`` (default ``{}``)
+
+Define priority of nodes for promotion, in case there are multiple candidates
+with the same replication position.  This allows to ensure all pglookout instances
+would elect the same standby for promotion, while still allowing for topologies
+with e.g. less preferred standbys in secondary network locations. By default,
+pglookout uses remote connection ids for the same selection purpose.
+
 ``known_gone_nodes`` (default ``[]``)
 
 Lists nodes that are explicitly known to have left the cluster.  If the old

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ exclude = [
     'test/test_lookout.py',
     'test/test_pgutil.py',
     'test/test_webserver.py',
+    'test/utils.py',
     # Other.
     'setup.py',
     'version.py',

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,86 @@
+"""
+Utilities for pglookout tests
+
+Copyright (c) 2015 Ohmu Ltd
+Copyright (c) 2014 F-Secure
+
+This file is under the Apache License, Version 2.0.
+See the file `LICENSE` for details.
+"""
+
+from pglookout.common import get_iso_timestamp
+
+
+def add_to_observer_state(
+    pgl,
+    observer_name,
+    db_name,
+    pg_last_xlog_receive_location=None,
+    pg_is_in_recovery=True,
+    connection=True,
+    replication_time_lag=None,
+    fetch_time=None,
+    db_time=None,
+):
+    db_node_state = create_db_node_state(
+        pg_last_xlog_receive_location,
+        pg_is_in_recovery,
+        connection,
+        replication_time_lag,
+        fetch_time=fetch_time,
+        db_time=db_time,
+    )
+    update_dict = {
+        "fetch_time": get_iso_timestamp(),  # type: ignore[no-untyped-call]
+        "connection": True,
+        db_name: db_node_state,
+    }
+    if observer_name in pgl.observer_state:
+        pgl.observer_state[observer_name].update(update_dict)
+    else:
+        pgl.observer_state[observer_name] = update_dict
+
+
+def create_db_node_state(
+    pg_last_xlog_receive_location=None,
+    pg_is_in_recovery=True,
+    connection=True,
+    replication_time_lag=None,
+    fetch_time=None,
+    db_time=None,
+):
+    return {
+        "connection": connection,
+        "db_time": get_iso_timestamp(db_time),
+        "fetch_time": get_iso_timestamp(fetch_time),
+        "pg_is_in_recovery": pg_is_in_recovery,
+        "pg_last_xact_replay_timestamp": None,
+        "pg_last_xlog_receive_location": pg_last_xlog_receive_location,
+        "pg_last_xlog_replay_location": None,
+        "replication_time_lag": replication_time_lag,
+        "min_replication_time_lag": 0,  # simulate that we've been in sync once
+    }
+
+
+def set_instance_cluster_state(
+    pgl,
+    *,
+    instance,
+    pg_last_xlog_receive_location=None,
+    pg_is_in_recovery=True,
+    connection=True,
+    replication_time_lag=None,
+    fetch_time=None,
+    db_time=None,
+    conn_info=None,
+):
+    db_node_state = create_db_node_state(
+        pg_last_xlog_receive_location,
+        pg_is_in_recovery,
+        connection,
+        replication_time_lag,
+        fetch_time=fetch_time,
+        db_time=db_time,
+    )
+    pgl.cluster_state[instance] = db_node_state
+    pgl.config["remote_conns"][instance] = conn_info or {"host": instance}


### PR DESCRIPTION
Support explicit prioritization between instances. This can be configured via ``failover_priorities`` key, and will be consulted upon picking up the standby that should do the promotion in cases where multiple nodes have a matching replication position.

Previously, and also as the current default, the selection was based on the sorting order of the remote nodes.

The configuration option allows some additional flexibility, and supports e.g. topologies where we have more favorable and less desirable standbys in multiple different network locations.